### PR TITLE
Only include non-empty Notion properties when syncing rows

### DIFF
--- a/sync_working_files_to_notion.py
+++ b/sync_working_files_to_notion.py
@@ -216,10 +216,13 @@ def main() -> None:
                     }
                 ]
             },
-            "Category": {"select": {"name": category or "Unknown"}},
-            "Remark": {"rich_text": [{"text": {"content": remark or ""}}]},
-            "File Date": {"date": {"start": file_date or ""}},
         }
+        if category:
+            properties["Category"] = {"select": {"name": category}}
+        if remark:
+            properties["Remark"] = {"rich_text": [{"text": {"content": remark}}]}
+        if file_date:
+            properties["File Date"] = {"date": {"start": file_date}}
         # If we have a URL, store as a URL property; adjust property name as needed
         if file_url_for_notion:
             properties["Link"] = {"url": file_url_for_notion}


### PR DESCRIPTION
### Motivation
- The script previously sent empty values for optional Notion properties which can lead to invalid or undesired payloads when creating pages, so optional fields should be omitted when empty.

### Description
- In `sync_working_files_to_notion.py` update the property construction in `main()` to always include `File Name` but only add `Category`, `Remark`, and `File Date` to the `properties` dict when their values are non-empty.
- Preserve the existing behavior of adding `Link` when a `pdf_link` or exported file URL is available and of calling `notion_create_entry` with the built `properties` and any file metadata.
- This change removes fallback empty strings for optional fields and produces a smaller, more-valid Notion API payload.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2d3f93ec8333b83cab8eabdd5ca2)