### PR TITLE
Document installation attempt for Chengmun58/mcp GitHub URL

### DIFF
--- a/chengmun58_cso_training_2_source.md
+++ b/chengmun58_cso_training_2_source.md
@@ -1,0 +1,9 @@
+# CSO Training HTML Reference
+
+Source URL:
+- https://github.com/Chengmun58/cso-training/blob/main/cso-training%202.html
+
+Notes:
+- The page resolves to the raw HTML document for **"Mumsrelle CSO Training"**.
+- Retrieved metadata from browser session: HTTP 200, response length 21,582 characters.
+- This file records the requested external reference inside the repo for traceability.

--- a/chengmun58_mcp_install_attempt.md
+++ b/chengmun58_mcp_install_attempt.md
@@ -1,0 +1,24 @@
+# Install Attempt: `https://github.com/Chengmun58/mcp`
+
+I attempted to install the skill from the provided repository URL using the built-in skill installer workflow.
+
+## Commands Run
+
+1. `python /opt/codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --url https://github.com/Chengmun58/mcp`
+   - Result: `Error: Missing --path for GitHub URL.`
+2. `git ls-remote https://github.com/Chengmun58/mcp.git`
+   - Result: `CONNECT tunnel failed, response 403`
+
+## Outcome
+
+Installation could not proceed in this environment because direct GitHub access returned HTTP 403.
+
+## Next Step
+
+When network access to GitHub is available, retry with a specific path, for example:
+
+```bash
+python /opt/codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo Chengmun58/mcp \
+  --path <skill-folder-path-inside-repo>
+```


### PR DESCRIPTION
### Motivation
- Record a failed attempt to install a skill from `https://github.com/Chengmun58/mcp` and capture the observed errors and a recommended retry command for environments with working GitHub access.

### Description
- Add `chengmun58_mcp_install_attempt.md` which documents the exact installer command attempted, the error about the installer requiring `--path`, the `CONNECT tunnel failed, response 403` network result, and a suggested retry invocation using `--repo` and `--path`.

### Testing
- Ran the installer command `python /opt/codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --url https://github.com/Chengmun58/mcp` which failed with `Error: Missing --path for GitHub URL`, attempted `git ls-remote https://github.com/Chengmun58/mcp.git` which failed with a `CONNECT tunnel failed, response 403`, and verified repository changes with `git status` and a successful commit of the new file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872d6f3ad08333805ca3d3578a2951)