### PR TITLE
Add local reference note for CSO training HTML URL

### DIFF
--- a/chengmun58_cso_training_2_source.md
+++ b/chengmun58_cso_training_2_source.md
@@ -1,0 +1,9 @@
+# CSO Training HTML Reference
+
+Source URL:
+- https://github.com/Chengmun58/cso-training/blob/main/cso-training%202.html
+
+Notes:
+- The page resolves to the raw HTML document for **"Mumsrelle CSO Training"**.
+- Retrieved metadata from browser session: HTTP 200, response length 21,582 characters.
+- This file records the requested external reference inside the repo for traceability.


### PR DESCRIPTION
### Motivation
- Record the external HTML reference inside the repository so the requested GitHub page (cso-training 2.html) is traceable without relying on direct network access.

### Description
- Added `chengmun58_cso_training_2_source.md` containing the source URL and observed retrieval metadata (page title context, HTTP 200, response length 21,582); no Codex skills were used because this is a simple local reference note.

### Testing
- Performed an automated browser retrieval via `Playwright` which returned HTTP 200 and a response length of 21,582 (success), while a direct `curl` fetch was blocked by the environment proxy (CONNECT tunnel failed, 403); the new file `chengmun58_cso_training_2_source.md` was created and recorded in the repository index.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885b67f3bc8333923223bbff31b227)